### PR TITLE
History set to false, true generates incomplete ref to imgs in Saved:

### DIFF
--- a/.buildpath
+++ b/.buildpath
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buildpath>
+	<buildpathentry kind="src" path=""/>
+	<buildpathentry kind="con" path="org.eclipse.php.core.LANGUAGE"/>
+</buildpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>quiz-archive</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.dltk.core.scriptbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.php.core.PHPNature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.php.core.prefs
+++ b/.settings/org.eclipse.php.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+include_path=0;/quiz-archive

--- a/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faceted-project>
+  <fixed facet="php.component"/>
+  <fixed facet="php.core.component"/>
+  <installed facet="php.core.component" version="1"/>
+  <installed facet="php.component" version="7.3"/>
+</faceted-project>

--- a/report.php
+++ b/report.php
@@ -302,7 +302,7 @@ class quiz_archive_report extends quiz_default_report {
             $displayoptions->marks = 2;
             $displayoptions->manualcomment = 1;
             $displayoptions->feedback = 1;
-            $displayoptions->history = true;
+            $displayoptions->history = false;
             $displayoptions->correctness = 1;
             $displayoptions->numpartscorrect = 1;
             $displayoptions->flags = 1;


### PR DESCRIPTION
for unfinished attempt (Moodle bug).
Sry for  the messy format of the comment. Just added files for the Eclipse project for this and just turned true into false in one line of code to avoid History when dumping the archive. 
Indeed the document is already long enough without the History and reporting history includes broken references to images in quiz. This takes place only in history (other references to imgs in the archive are ok) and these broken imgs are   already in quiz reports from Moodle code so... When using this (saved as a PDF page) as evidence in formal setting (e.g. parent meeting) to support bad  notes prefer not to have broken references that could be impair the formal value of the document.  See the Export format using this to create the archive dump of all the notes for oll the students in a course in my repository  https://github.com/TWINGSISTER/moodle-grade-extended